### PR TITLE
Add dropdown menu to Launch in OpenHands button with contextual options

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,15 +1,18 @@
 // Function to add the OpenHands button to GitHub repository pages
 function addOpenHandsButton() {
-  // Check if we're on a GitHub repository page or a pull request page
+  // Check if we're on a GitHub repository page, pull request page, or issue page
   const isRepoPage = window.location.pathname.split('/').length === 3 || 
                      (window.location.pathname.split('/').length > 3 && 
-                      !window.location.pathname.includes('/pull/'));
+                      !window.location.pathname.includes('/pull/') &&
+                      !window.location.pathname.includes('/issues/'));
   const isPRPage = window.location.pathname.includes('/pull/');
+  const isIssuePage = window.location.pathname.includes('/issues/') && 
+                      window.location.pathname.split('/').length > 4; // Make sure it's a specific issue
   
-  if (!isRepoPage && !isPRPage) return;
+  if (!isRepoPage && !isPRPage && !isIssuePage) return;
 
   // Remove any existing OpenHands buttons to avoid duplicates
-  const existingButtons = document.querySelectorAll('.openhands-launch-btn');
+  const existingButtons = document.querySelectorAll('.openhands-container');
   existingButtons.forEach(button => button.remove());
 
   // Find the container where we want to add our button
@@ -17,23 +20,115 @@ function addOpenHandsButton() {
   if (isRepoPage) {
     // For repository pages, find the container with star/watch/fork buttons
     container = document.querySelector('ul.pagehead-actions');
-  } else if (isPRPage) {
-    // For PR pages, find the container with PR actions
+  } else if (isPRPage || isIssuePage) {
+    // For PR pages or issue pages, find the container with actions
     container = document.querySelector('.gh-header-actions');
   }
 
   if (!container) return;
 
-  // Create our button
+  // Create our button container
   const listItem = document.createElement('li');
   listItem.className = 'openhands-list-item';
   
+  const buttonContainer = document.createElement('div');
+  buttonContainer.className = 'openhands-container';
+  
+  // Create main button
   const button = document.createElement('button');
   button.className = 'openhands-launch-btn';
   button.innerHTML = '<img src="' + chrome.runtime.getURL('images/openhands-logo.svg') + '" class="openhands-logo" alt="OpenHands Logo"><span>Launch in OpenHands</span>';
   button.title = 'Start an OpenHands conversation for this repository';
   
-  // Add click event listener
+  // Create dropdown toggle button
+  const dropdownToggle = document.createElement('button');
+  dropdownToggle.className = 'openhands-dropdown-toggle';
+  dropdownToggle.innerHTML = '<span class="openhands-caret">▼</span>';
+  dropdownToggle.title = 'Show OpenHands options';
+  
+  // Create dropdown menu
+  const dropdownMenu = document.createElement('div');
+  dropdownMenu.className = 'openhands-dropdown-menu';
+  
+  // Get repository information
+  const repoInfo = getRepositoryInfo();
+  
+  // Add appropriate dropdown items based on page type
+  if (isRepoPage) {
+    // Repository home page options
+    addDropdownItem(dropdownMenu, `New conversation for ${repoInfo.fullRepo}`, () => {
+      handleRepoLaunch(repoInfo, `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please ask what task I'd like to perform.`);
+    });
+    
+    addDropdownItem(dropdownMenu, 'Learn about this codebase', () => {
+      handleRepoLaunch(repoInfo, `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please help me understand this codebase.`);
+    });
+    
+    // Check if repo.md exists
+    const repoMdElement = document.querySelector('a[href$="/repo.md"]');
+    if (!repoMdElement) {
+      addDropdownItem(dropdownMenu, 'Add a repo.md microagent', () => {
+        handleRepoLaunch(repoInfo, `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please create a repo.md microagent file.`);
+      });
+    }
+    
+    // Check if setup.sh exists
+    const setupShElement = document.querySelector('a[href$="/setup.sh"]');
+    if (!setupShElement) {
+      addDropdownItem(dropdownMenu, 'Add setup.sh', () => {
+        handleRepoLaunch(repoInfo, `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please create a setup.sh script.`);
+      });
+    }
+  } else if (isPRPage) {
+    // Pull request options
+    const prNumber = repoInfo.prNumber;
+    
+    addDropdownItem(dropdownMenu, `New conversation for PR #${prNumber}`, () => {
+      handlePRLaunch(repoInfo);
+    });
+    
+    // Check for failing GitHub actions
+    const failingChecks = document.querySelectorAll('.checks-summary-conclusion-failure');
+    if (failingChecks.length > 0) {
+      addDropdownItem(dropdownMenu, 'Fix failing GitHub actions', () => {
+        const instruction = `You are working on PR #${prNumber} (${repoInfo.url}). Please help me fix the failing GitHub actions.`;
+        handlePRLaunch(repoInfo, instruction);
+      });
+    }
+    
+    // Check for merge conflicts
+    const mergeConflicts = document.querySelector('.branch-action-item.color-border-danger');
+    if (mergeConflicts) {
+      addDropdownItem(dropdownMenu, 'Resolve merge conflicts', () => {
+        const instruction = `You are working on PR #${prNumber} (${repoInfo.url}). Please help me resolve the merge conflicts.`;
+        handlePRLaunch(repoInfo, instruction);
+      });
+    }
+    
+    // Check for code review comments
+    const reviewComments = document.querySelectorAll('.js-comment');
+    if (reviewComments.length > 0) {
+      addDropdownItem(dropdownMenu, 'Address code review feedback', () => {
+        const instruction = `You are working on PR #${prNumber} (${repoInfo.url}). Please help me address the code review feedback.`;
+        handlePRLaunch(repoInfo, instruction);
+      });
+    }
+  } else if (isIssuePage) {
+    // Issue options
+    const issueNumber = window.location.pathname.split('/').pop();
+    
+    addDropdownItem(dropdownMenu, `Investigate Issue #${issueNumber}`, () => {
+      const instruction = `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please help me investigate Issue #${issueNumber} (${repoInfo.url}).`;
+      handleRepoLaunch(repoInfo, instruction);
+    });
+    
+    addDropdownItem(dropdownMenu, `Solve Issue #${issueNumber}`, () => {
+      const instruction = `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please help me solve Issue #${issueNumber} (${repoInfo.url}).`;
+      handleRepoLaunch(repoInfo, instruction);
+    });
+  }
+  
+  // Add click event listener to main button
   button.addEventListener('click', async () => {
     // Get repository information
     const repoInfo = getRepositoryInfo();
@@ -45,8 +140,43 @@ function addOpenHandsButton() {
     }
   });
   
-  listItem.appendChild(button);
+  // Add click event listener to dropdown toggle
+  dropdownToggle.addEventListener('click', (event) => {
+    event.stopPropagation();
+    dropdownMenu.classList.toggle('show');
+    
+    // Close dropdown when clicking outside
+    const closeDropdown = (e) => {
+      if (!dropdownMenu.contains(e.target) && e.target !== dropdownToggle) {
+        dropdownMenu.classList.remove('show');
+        document.removeEventListener('click', closeDropdown);
+      }
+    };
+    
+    document.addEventListener('click', closeDropdown);
+  });
+  
+  // Add elements to the DOM
+  buttonContainer.appendChild(button);
+  buttonContainer.appendChild(dropdownToggle);
+  buttonContainer.appendChild(dropdownMenu);
+  listItem.appendChild(buttonContainer);
   container.appendChild(listItem);
+}
+
+// Helper function to add dropdown items
+function addDropdownItem(menu, text, clickHandler) {
+  const item = document.createElement('a');
+  item.className = 'openhands-dropdown-item';
+  item.textContent = text;
+  item.href = '#';
+  item.addEventListener('click', (event) => {
+    event.preventDefault();
+    clickHandler();
+    // Hide dropdown after clicking
+    menu.classList.remove('show');
+  });
+  menu.appendChild(item);
 }
 
 // Function to get repository information from the current page
@@ -80,7 +210,7 @@ function getRepositoryInfo() {
 }
 
 // Function to handle launching OpenHands for a repository
-async function handleRepoLaunch(repoInfo) {
+async function handleRepoLaunch(repoInfo, customMessage) {
   try {
     // Get API key from storage
     const { apiKey } = await chrome.storage.sync.get('apiKey');
@@ -94,11 +224,14 @@ async function handleRepoLaunch(repoInfo) {
     // Show loading state
     updateButtonState('loading');
     
+    // Use custom message if provided, otherwise use default
+    const initialMessage = customMessage || `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please ask what task I'd like to perform.`;
+    
     // Send message to background script to make API request
     chrome.runtime.sendMessage({
       action: 'startConversation',
       data: {
-        initial_user_msg: `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please ask what task I'd like to perform.`,
+        initial_user_msg: initialMessage,
         repository: repoInfo.fullRepo
       }
     }, response => {
@@ -126,7 +259,7 @@ async function handleRepoLaunch(repoInfo) {
 }
 
 // Function to handle launching OpenHands for a pull request
-async function handlePRLaunch(repoInfo) {
+async function handlePRLaunch(repoInfo, customMessage) {
   try {
     // Get API key from storage
     const { apiKey } = await chrome.storage.sync.get('apiKey');
@@ -153,7 +286,10 @@ async function handlePRLaunch(repoInfo) {
     }
     
     // Create instruction for PR review
-    const instruction = `You are working on a PR ${repoInfo.url}, and you should check out to branch ${repoInfo.prBranch || 'the PR branch'} that corresponds to this PR, read the git diff against main branch, understand the purpose of this PR, and then awaits me for further instructions.`;
+    const defaultInstruction = `You are working on a PR ${repoInfo.url}, and you should check out to branch ${repoInfo.prBranch || 'the PR branch'} that corresponds to this PR, read the git diff against main branch, understand the purpose of this PR, and then awaits me for further instructions.`;
+    
+    // Use custom message if provided, otherwise use default
+    const instruction = customMessage || defaultInstruction;
     
     // Send message to background script to make API request
     chrome.runtime.sendMessage({
@@ -213,6 +349,7 @@ function getPRForkInfo() {
 // Function to update button state (loading, success, error)
 function updateButtonState(state) {
   const button = document.querySelector('.openhands-launch-btn');
+  const dropdownToggle = document.querySelector('.openhands-dropdown-toggle');
   if (!button) return;
   
   // Get logo HTML
@@ -224,21 +361,41 @@ function updateButtonState(state) {
   if (state === 'loading') {
     button.classList.add('loading');
     button.innerHTML = `${logoHTML}<span>Launching...</span>`;
+    
+    // Disable dropdown toggle during loading
+    if (dropdownToggle) {
+      dropdownToggle.disabled = true;
+      dropdownToggle.classList.add('disabled');
+    }
   } else if (state === 'success') {
     button.classList.add('success');
     button.innerHTML = `${logoHTML}<span>Launched!</span>`;
+    
     // Reset after 3 seconds
     setTimeout(() => {
       button.classList.remove('success');
       button.innerHTML = `${logoHTML}<span>Launch in OpenHands</span>`;
+      
+      // Re-enable dropdown toggle
+      if (dropdownToggle) {
+        dropdownToggle.disabled = false;
+        dropdownToggle.classList.remove('disabled');
+      }
     }, 3000);
   } else if (state === 'error') {
     button.classList.add('error');
     button.innerHTML = `${logoHTML}<span>Failed to launch</span>`;
+    
     // Reset after 3 seconds
     setTimeout(() => {
       button.classList.remove('error');
       button.innerHTML = `${logoHTML}<span>Launch in OpenHands</span>`;
+      
+      // Re-enable dropdown toggle
+      if (dropdownToggle) {
+        dropdownToggle.disabled = false;
+        dropdownToggle.classList.remove('disabled');
+      }
     }, 3000);
   }
 }

--- a/content.js
+++ b/content.js
@@ -57,18 +57,18 @@ function addOpenHandsButton() {
   if (isRepoPage) {
     // Repository home page options
     addDropdownItem(dropdownMenu, `New conversation for ${repoInfo.fullRepo}`, () => {
-      handleRepoLaunch(repoInfo, `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please ask what task I'd like to perform.`);
+      handleRepoLaunch(repoInfo, REPO_PROMPTS.DEFAULT(repoInfo));
     });
     
     addDropdownItem(dropdownMenu, 'Learn about this codebase', () => {
-      handleRepoLaunch(repoInfo, `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please help me understand this codebase.`);
+      handleRepoLaunch(repoInfo, REPO_PROMPTS.LEARN_CODEBASE(repoInfo));
     });
     
     // Check if repo.md exists
     const repoMdElement = document.querySelector('a[href$="/repo.md"]');
     if (!repoMdElement) {
       addDropdownItem(dropdownMenu, 'Add a repo.md microagent', () => {
-        handleRepoLaunch(repoInfo, `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please create a repo.md microagent file.`);
+        handleRepoLaunch(repoInfo, REPO_PROMPTS.ADD_REPO_MD(repoInfo));
       });
     }
     
@@ -76,7 +76,7 @@ function addOpenHandsButton() {
     const setupShElement = document.querySelector('a[href$="/setup.sh"]');
     if (!setupShElement) {
       addDropdownItem(dropdownMenu, 'Add setup.sh', () => {
-        handleRepoLaunch(repoInfo, `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please create a setup.sh script.`);
+        handleRepoLaunch(repoInfo, REPO_PROMPTS.ADD_SETUP_SH(repoInfo));
       });
     }
   } else if (isPRPage) {
@@ -91,8 +91,7 @@ function addOpenHandsButton() {
     const failingChecks = document.querySelectorAll('.checks-summary-conclusion-failure');
     if (failingChecks.length > 0) {
       addDropdownItem(dropdownMenu, 'Fix failing GitHub actions', () => {
-        const instruction = `You are working on PR #${prNumber} (${repoInfo.url}). Please help me fix the failing GitHub actions.`;
-        handlePRLaunch(repoInfo, instruction);
+        handlePRLaunch(repoInfo, PR_PROMPTS.FIX_ACTIONS(repoInfo));
       });
     }
     
@@ -100,8 +99,7 @@ function addOpenHandsButton() {
     const mergeConflicts = document.querySelector('.branch-action-item.color-border-danger');
     if (mergeConflicts) {
       addDropdownItem(dropdownMenu, 'Resolve merge conflicts', () => {
-        const instruction = `You are working on PR #${prNumber} (${repoInfo.url}). Please help me resolve the merge conflicts.`;
-        handlePRLaunch(repoInfo, instruction);
+        handlePRLaunch(repoInfo, PR_PROMPTS.RESOLVE_CONFLICTS(repoInfo));
       });
     }
     
@@ -109,8 +107,7 @@ function addOpenHandsButton() {
     const reviewComments = document.querySelectorAll('.js-comment');
     if (reviewComments.length > 0) {
       addDropdownItem(dropdownMenu, 'Address code review feedback', () => {
-        const instruction = `You are working on PR #${prNumber} (${repoInfo.url}). Please help me address the code review feedback.`;
-        handlePRLaunch(repoInfo, instruction);
+        handlePRLaunch(repoInfo, PR_PROMPTS.ADDRESS_FEEDBACK(repoInfo));
       });
     }
   } else if (isIssuePage) {
@@ -118,13 +115,11 @@ function addOpenHandsButton() {
     const issueNumber = window.location.pathname.split('/').pop();
     
     addDropdownItem(dropdownMenu, `Investigate Issue #${issueNumber}`, () => {
-      const instruction = `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please help me investigate Issue #${issueNumber} (${repoInfo.url}).`;
-      handleRepoLaunch(repoInfo, instruction);
+      handleRepoLaunch(repoInfo, ISSUE_PROMPTS.INVESTIGATE(repoInfo, issueNumber));
     });
     
     addDropdownItem(dropdownMenu, `Solve Issue #${issueNumber}`, () => {
-      const instruction = `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please help me solve Issue #${issueNumber} (${repoInfo.url}).`;
-      handleRepoLaunch(repoInfo, instruction);
+      handleRepoLaunch(repoInfo, ISSUE_PROMPTS.SOLVE(repoInfo, issueNumber));
     });
   }
   
@@ -225,7 +220,7 @@ async function handleRepoLaunch(repoInfo, customMessage) {
     updateButtonState('loading');
     
     // Use custom message if provided, otherwise use default
-    const initialMessage = customMessage || `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please ask what task I'd like to perform.`;
+    const initialMessage = customMessage || REPO_PROMPTS.DEFAULT(repoInfo);
     
     // Send message to background script to make API request
     chrome.runtime.sendMessage({
@@ -285,11 +280,8 @@ async function handlePRLaunch(repoInfo, customMessage) {
       }
     }
     
-    // Create instruction for PR review
-    const defaultInstruction = `You are working on a PR ${repoInfo.url}, and you should check out to branch ${repoInfo.prBranch || 'the PR branch'} that corresponds to this PR, read the git diff against main branch, understand the purpose of this PR, and then awaits me for further instructions.`;
-    
     // Use custom message if provided, otherwise use default
-    const instruction = customMessage || defaultInstruction;
+    const instruction = customMessage || PR_PROMPTS.DEFAULT(repoInfo);
     
     // Send message to background script to make API request
     chrome.runtime.sendMessage({

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,7 @@
   "content_scripts": [
     {
       "matches": ["https://github.com/*"],
-      "js": ["content.js"],
+      "js": ["prompts.js", "content.js"],
       "css": ["styles.css"]
     }
   ],

--- a/prompts.js
+++ b/prompts.js
@@ -1,0 +1,41 @@
+// Prompts for OpenHands Chrome Extension
+// This file contains all the prompts used in the extension
+
+// Repository prompts
+const REPO_PROMPTS = {
+  // Default prompt for repository
+  DEFAULT: (repoInfo) => `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please ask what task I'd like to perform.`,
+  
+  // Learn about codebase prompt
+  LEARN_CODEBASE: (repoInfo) => `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please help me understand this codebase.`,
+  
+  // Add repo.md microagent prompt
+  ADD_REPO_MD: (repoInfo) => `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please create a repo.md microagent file.`,
+  
+  // Add setup.sh prompt
+  ADD_SETUP_SH: (repoInfo) => `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please create a setup.sh script.`
+};
+
+// Pull request prompts
+const PR_PROMPTS = {
+  // Default prompt for PR
+  DEFAULT: (repoInfo) => `You are working on a PR ${repoInfo.url}, and you should check out to branch ${repoInfo.prBranch || 'the PR branch'} that corresponds to this PR, read the git diff against main branch, understand the purpose of this PR, and then awaits me for further instructions.`,
+  
+  // Fix failing GitHub actions prompt
+  FIX_ACTIONS: (repoInfo) => `You are working on PR #${repoInfo.prNumber} (${repoInfo.url}). Please help me fix the failing GitHub actions.`,
+  
+  // Resolve merge conflicts prompt
+  RESOLVE_CONFLICTS: (repoInfo) => `You are working on PR #${repoInfo.prNumber} (${repoInfo.url}). Please help me resolve the merge conflicts.`,
+  
+  // Address code review feedback prompt
+  ADDRESS_FEEDBACK: (repoInfo) => `You are working on PR #${repoInfo.prNumber} (${repoInfo.url}). Please help me address the code review feedback.`
+};
+
+// Issue prompts
+const ISSUE_PROMPTS = {
+  // Investigate issue prompt
+  INVESTIGATE: (repoInfo, issueNumber) => `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please help me investigate Issue #${issueNumber} (${repoInfo.url}).`,
+  
+  // Solve issue prompt
+  SOLVE: (repoInfo, issueNumber) => `I've launched OpenHands for the ${repoInfo.fullRepo} repository. Please help me solve Issue #${issueNumber} (${repoInfo.url}).`
+};

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,9 @@
+/* Container for the button and dropdown */
+.openhands-container {
+  display: flex;
+  position: relative;
+}
+
 /* Styles for the OpenHands button */
 .openhands-launch-btn {
   display: inline-flex;
@@ -11,13 +17,14 @@
   cursor: pointer;
   user-select: none;
   border: 1px solid rgba(27, 31, 36, 0.15);
-  border-radius: 6px;
+  border-radius: 6px 0 0 6px; /* Rounded only on left side */
   appearance: none;
   background-color: rgba(201, 185, 116, 0.9); /* OpenHands yellow with slight transparency */
   color: #0D0F11; /* OpenHands base dark color for text */
   transition: background-color 0.2s;
   margin-left: 8px;
   position: relative;
+  border-right: none; /* Remove right border for seamless connection with dropdown toggle */
 }
 
 .openhands-launch-btn:hover {
@@ -41,6 +48,86 @@
   background-color: #E76A5E; /* OpenHands danger color */
 }
 
+/* Dropdown toggle button */
+.openhands-dropdown-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 6px;
+  font-size: 12px;
+  line-height: 20px;
+  cursor: pointer;
+  user-select: none;
+  border: 1px solid rgba(27, 31, 36, 0.15);
+  border-radius: 0 6px 6px 0; /* Rounded only on right side */
+  appearance: none;
+  background-color: rgba(201, 185, 116, 0.9); /* Match main button */
+  color: #0D0F11;
+  transition: background-color 0.2s;
+}
+
+.openhands-dropdown-toggle:hover {
+  background-color: #C9B974; /* Match main button hover */
+}
+
+.openhands-dropdown-toggle:active {
+  background-color: #CFB755; /* Match main button active */
+}
+
+.openhands-dropdown-toggle.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Caret icon */
+.openhands-caret {
+  font-size: 8px;
+  display: inline-block;
+}
+
+/* Dropdown menu */
+.openhands-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 100;
+  display: none;
+  min-width: 240px;
+  padding: 4px 0;
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: #24292f;
+  text-align: left;
+  list-style: none;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid rgba(27, 31, 36, 0.15);
+  border-radius: 6px;
+  box-shadow: 0 1px 5px rgba(27, 31, 36, 0.15);
+}
+
+.openhands-dropdown-menu.show {
+  display: block;
+}
+
+/* Dropdown items */
+.openhands-dropdown-item {
+  display: block;
+  padding: 4px 16px;
+  color: #24292f;
+  text-decoration: none;
+  white-space: nowrap;
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
+.openhands-dropdown-item:hover {
+  color: #ffffff;
+  text-decoration: none;
+  background-color: #0969da;
+}
+
 /* OpenHands logo in button */
 .openhands-logo {
   width: 16px;
@@ -58,6 +145,6 @@
 }
 
 /* For PR pages */
-.gh-header-actions .openhands-launch-btn {
+.gh-header-actions .openhands-container {
   margin-right: 8px;
 }


### PR DESCRIPTION
This PR adds a dropdown menu to the "Launch in OpenHands" button with contextual options based on the page type.

### Changes:

- Added a dropdown toggle button (caret down) next to the main button
- Implemented contextual dropdown menu with different options based on page type:

#### Repository home page options:
- "New conversation for $ORG/$REPO"
- "Learn about this codebase"
- "Add a repo.md microagent" (if none exists)
- "Add setup.sh" (if none exists)

#### Pull request options:
- "New conversation for PR #123"
- "Fix failing GitHub actions" (if there are failures)
- "Resolve merge conflicts" (if there are any)
- "Address code review feedback" (if there is any)

#### Issue page options:
- "Investigate Issue #123"
- "Solve Issue #123"

### Implementation details:
- Added CSS styles for the dropdown menu and items
- Updated button handlers to accept custom messages
- Added logic to detect page context and show appropriate options
- Implemented proper event handling for the dropdown

The implementation follows GitHub UI patterns for dropdown menus, ensuring a consistent and familiar experience for users.