### PR TITLE
Fix extension not working on PR and issue pages

### DIFF
--- a/content-bundle.js
+++ b/content-bundle.js
@@ -22,10 +22,33 @@ function detectPageType() {
   };
 }
 
-// Finds the appropriate container for the OpenHands button based on page type
+// Finds (or creates) the container for the OpenHands button
 function findButtonContainer() {
-  // ul.pagehead-actions is present on all GitHub repo pages (repo, PR, issue)
-  return document.querySelector('ul.pagehead-actions');
+  // Old GitHub layout: pagehead-actions bar (Watch/Fork/Star row)
+  const pagehead = document.querySelector('ul.pagehead-actions');
+  if (pagehead) return pagehead;
+
+  // Legacy PR/issue header actions
+  const ghHeader = document.querySelector('.gh-header-actions');
+  if (ghHeader) return ghHeader;
+
+  // Re-use our previously injected container if it exists
+  const existing = document.querySelector('.openhands-injected-container');
+  if (existing) return existing;
+
+  // New GitHub layout: create a container and insert it after the repo tab nav
+  const repoNav = document.querySelector('.UnderlineNav')
+    || document.querySelector('nav[aria-label="Repository"]')
+    || document.querySelector('.js-repo-nav');
+  if (repoNav) {
+    const container = document.createElement('ul');
+    container.className = 'pagehead-actions openhands-injected-container';
+    container.style.cssText = 'list-style:none; display:flex; padding:4px 16px; margin:0;';
+    repoNav.parentElement.insertBefore(container, repoNav.nextSibling);
+    return container;
+  }
+
+  return null;
 }
 
 // Extracts repository information from the current page

--- a/content-bundle.js
+++ b/content-bundle.js
@@ -43,7 +43,7 @@ function findButtonContainer() {
   if (repoNav) {
     const container = document.createElement('ul');
     container.className = 'pagehead-actions openhands-injected-container';
-    container.style.cssText = 'list-style:none; display:flex; padding:4px 16px; margin:0;';
+    container.style.cssText = 'list-style:none; display:flex; justify-content:flex-end; padding:4px 16px; margin:0;';
     repoNav.parentElement.insertBefore(container, repoNav.nextSibling);
     return container;
   }

--- a/content-bundle.js
+++ b/content-bundle.js
@@ -24,22 +24,8 @@ function detectPageType() {
 
 // Finds the appropriate container for the OpenHands button based on page type
 function findButtonContainer() {
-  const { isRepoPage, isPRPage, isIssuePage } = detectPageType();
-
-  let container = null;
-
-  if (isRepoPage) {
-    // For repository pages, find the container with repository actions
-    container = document.querySelector('ul.pagehead-actions');
-  } else if (isPRPage) {
-    // For PR pages, find the container with PR actions
-    container = document.querySelector('.gh-header-actions');
-  } else if (isIssuePage) {
-    // For issue pages, find the container with issue actions
-    container = document.querySelector('.gh-header-actions');
-  }
-
-  return container;
+  // ul.pagehead-actions is present on all GitHub repo pages (repo, PR, issue)
+  return document.querySelector('ul.pagehead-actions');
 }
 
 // Extracts repository information from the current page
@@ -62,10 +48,20 @@ function getRepositoryInfo() {
     if (prIndex >= 0 && prIndex + 1 < pathParts.length) {
       prNumber = pathParts[prIndex + 1];
     }
-    if (!prBranch) {
-      const branchSpan = document.querySelector('span.head-ref');
-      if (branchSpan) {
-        prBranch = branchSpan.textContent.trim();
+    // Try legacy selector first, then fall back to new GitHub UI selector
+    const branchSpan = document.querySelector('span.head-ref');
+    if (branchSpan) {
+      prBranch = branchSpan.textContent.trim();
+    } else {
+      // New GitHub UI uses BranchName links: [base-branch, head-branch]
+      const branchLinks = document.querySelectorAll('a[class*="BranchName"]');
+      if (branchLinks.length >= 2) {
+        let branchText = branchLinks[1].textContent.trim();
+        // Remove owner prefix if present (e.g., "user:branch-name" -> "branch-name")
+        if (branchText.includes(':')) {
+          branchText = branchText.split(':')[1];
+        }
+        prBranch = branchText;
       }
     }
   } else if (pathParts.includes('issues')) {
@@ -88,22 +84,38 @@ function getRepositoryInfo() {
 
 // Extracts information about a PR from a forked repository
 function getPRForkInfo() {
-  // Look for the fork indicator in the PR
+  // Try legacy selector first
   const forkIndicator = document.querySelector('.fork-flag');
-
   if (forkIndicator) {
-    // Extract the fork owner and repo
     const forkLink = document.querySelector('.fork-flag a');
-
     if (forkLink) {
       const forkPath = new URL(forkLink.href).pathname;
       const forkParts = forkPath.split('/').filter(part => part.length > 0);
-
       if (forkParts.length >= 2) {
         return {
           owner: forkParts[0],
           repo: forkParts[1],
           fullRepo: `${forkParts[0]}/${forkParts[1]}`
+        };
+      }
+    }
+  }
+
+  // New GitHub UI: extract fork info from BranchName links
+  // Head branch link href format: /fork-owner/repo/tree/branch-name
+  const pathParts = window.location.pathname.split('/').filter(part => part.length > 0);
+  const repoOwner = pathParts[0];
+  const branchLinks = document.querySelectorAll('a[class*="BranchName"]');
+  if (branchLinks.length >= 2) {
+    const headBranchHref = branchLinks[1].getAttribute('href');
+    if (headBranchHref) {
+      const hrefParts = headBranchHref.split('/').filter(part => part.length > 0);
+      // hrefParts: [owner, repo, 'tree', branch-name]
+      if (hrefParts.length >= 2 && hrefParts[0] !== repoOwner) {
+        return {
+          owner: hrefParts[0],
+          repo: hrefParts[1],
+          fullRepo: `${hrefParts[0]}/${hrefParts[1]}`
         };
       }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenHands Chrome Extension",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Launch OpenHands conversations directly from GitHub repositories and pull requests",
   "permissions": ["storage", "activeTab", "scripting"],
   "host_permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenHands Chrome Extension",
-  "version": "1.1",
+  "version": "1.2",
   "description": "Launch OpenHands conversations directly from GitHub repositories and pull requests",
   "permissions": ["storage", "activeTab", "scripting"],
   "host_permissions": [


### PR DESCRIPTION
## Summary

The extension fails to inject the "Launch with OpenHands" button on pages using GitHub's new UI layout (notably private repos and the new PR layout), because the `ul.pagehead-actions` container no longer exists.

## Root Cause

GitHub's new React-based UI replaces the server-rendered HTML after hydration. The old `ul.pagehead-actions` (Watch/Fork/Star row), `.gh-header-actions`, `span.head-ref`, and `.fork-flag` selectors no longer exist in the rendered DOM on the new layout.

## Changes

### Button container (`findButtonContainer`) — Fallback chain
Instead of relying on a single selector, the function now tries multiple approaches in order:

1. `ul.pagehead-actions` — old layout (public repos)
2. `.gh-header-actions` — legacy PR/issue header
3. `.openhands-injected-container` — re-use our own container if already created
4. **Create a new container** after the repo tab navigation (`.UnderlineNav` / `nav[aria-label="Repository"]` / `.js-repo-nav`)

This ensures the button appears regardless of which GitHub layout is active.

### PR branch detection (`getRepositoryInfo`)
- **Old**: `span.head-ref` (no longer exists)
- **New**: Falls back to `a[class*="BranchName"]` links, correctly parsing branch names and stripping fork owner prefixes (e.g. `afangster:local-step` → `local-step`)

### PR fork detection (`getPRForkInfo`)
- **Old**: `.fork-flag` element (no longer exists)
- **New**: Falls back to comparing the head branch link's `href` owner against the repo owner from the URL

All changes retain legacy selectors as a first attempt for backward compatibility.

### Version
- Bumped from `1.1` → `1.2`

## Testing

Visual injection test against mock GitHub layouts:
- ✅ Public repo PR (old layout with pagehead-actions) — button in pagehead row
- ✅ Private repo PR (new layout, NO pagehead-actions) — button via injected container below tab nav
- ✅ Issue page (no pagehead-actions) — button via injected container below tab nav